### PR TITLE
Workaround about Filters Members for KPIs

### DIFF
--- a/MDX2JSON/Utils.cls
+++ b/MDX2JSON/Utils.cls
@@ -184,14 +184,16 @@ ClassMethod WriteFiltersForDataSource(pDataSource As %String, pValues As %Boolea
 		while (key '= "") {
 			set st = ##class(%DeepSee.Dashboard.Utils).%GetMembersForFilter(pDataSource,$lg(tFilters(key),2),.tMembers,.tDefaultFilterValue,pSearchKey,.pRelatedFilters,0,,.tValueList)
 			return:$$$ISERR(st) st
+			if +$g(tMembers) set tMembers = $g(tFilters(key)) // check if list contain simple number and replace it with proper query
 			merge tFilters(key) = tMembers // merge filter values
 			set key = $order(tFilters(key))
 	   	}
 	}
    	
-   	set st = ##class(%ZEN.Auxiliary.jsonProvider).%ArrayToJSON($lb("name","path","info"),.tFilters)
 
-	return st
+   	Set tAET = ##class(%ZEN.Auxiliary.altJSONProvider).%ArrayToAET($lb("name", "path", "info"), .tFilters)
+	do tAET.%ToJSON()
+	return tAET
 }
 
 /// Get information about pivot. <br>

--- a/MDX2JSON/Utils.cls
+++ b/MDX2JSON/Utils.cls
@@ -193,7 +193,8 @@ ClassMethod WriteFiltersForDataSource(pDataSource As %String, pValues As %Boolea
 
    	Set tAET = ##class(%ZEN.Auxiliary.altJSONProvider).%ArrayToAET($lb("name", "path", "info"), .tFilters)
 	do tAET.%ToJSON()
-	return tAET
+	set st = tAET
+	return st
 }
 
 /// Get information about pivot. <br>

--- a/MDX2JSON/Utils.cls
+++ b/MDX2JSON/Utils.cls
@@ -191,9 +191,7 @@ ClassMethod WriteFiltersForDataSource(pDataSource As %String, pValues As %Boolea
 	}
    	
 
-   	Set tAET = ##class(%ZEN.Auxiliary.altJSONProvider).%ArrayToAET($lb("name", "path", "info"), .tFilters)
-	do tAET.%ToJSON()
-	set st = tAET
+   	Set st = ##class(%ZEN.Auxiliary.altJSONProvider).%ArrayToJSON($lb("name", "path", "info"),.tFilters)
 	return st
 }
 


### PR DESCRIPTION
This is a first step for working filters: get correct list values for filters.
The problem is that some tMembers contain simple number like an index or amount of child members.
We just do replace them by the key.