### PR TITLE
Fix empty Titles (use Name)

### DIFF
--- a/MDX2JSON/DashboardRS.cls
+++ b/MDX2JSON/DashboardRS.cls
@@ -31,7 +31,11 @@ Method %Next(ByRef sc As %Library.Status) As %Integer [ PlaceAfter = %Execute ]
     set id = ..id
     return:id="" $$$NO
     
-    set ..title = ##class(%DeepSee.UserPortal.Utils).%ResolveText(##class(%DeepSee.UserLibrary.FolderItem).titleGetStored(id))
+	set title = ##class(%DeepSee.UserPortal.Utils).%ResolveText(##class(%DeepSee.UserLibrary.FolderItem).titleGetStored(id))
+	// While empty Title use Name instead
+	set:(title="") title = ##class(%DeepSee.UserPortal.Utils).%ResolveText(##class(%DeepSee.UserLibrary.FolderItem).nameGetStored(id))
+	
+    set ..title = title
     set ..path =  ..GetDashFullName(id)
     set ..cover = ##class(MDX2JSON.Dashboard).GetDashCover(##class(%DeepSee.UserLibrary.FolderItem).bookCoverGetStored(id))
     


### PR DESCRIPTION
Search don't work if empty title in Dashboard.
Use Name value instead of empty Title
https://github.com/intersystems-community/DeepSeeWeb/issues/322 