### PR TITLE
FIX: add fix for textMeters

### DIFF
--- a/MDX2JSON/ResultSet.cls
+++ b/MDX2JSON/ResultSet.cls
@@ -188,8 +188,8 @@ Method ProcessOneAxisCell(CubeIndex, AxisKey, CubeName, QueryKey, AxisNumber, No
 	set tCaption = $LG(tNode, 5)
 
 	do ##class(%DeepSee.Utils).%GetDimensionCaption(CubeName,tDimNo, tHierNo,tLevelNo, .tAxisCaption)
-	set cell.dimension = tAxisCaption // cube dimension
-	if (cell.dimension = "") {set cell.dimension = tCaption} // hack for assigne dimension property for calcMembers specifically
+	set cell.dimension = tCaption // cube dimension taken from the name of the axes.
+	if (cell.dimension = "") {set cell.dimension = tCaption} // hack for assigne dimension property in case of empty dimension
 	
 
 	set:$$$Debug cell.visible = '..IsCellNull(cell,AxisNumber,Node)


### PR DESCRIPTION
The dimension is taken from the name of the axes. The solution needs to be tested on a pie-chart, further work on the solution is expected 
Related issue
https://github.com/intersystems-community/DeepSeeWeb/issues/348