### PR TITLE
FIX: change the way how dataProperties are processed for text meters

### DIFF
--- a/MDX2JSON/Dashboard.cls
+++ b/MDX2JSON/Dashboard.cls
@@ -115,10 +115,7 @@ ClassMethod WidgetToProxyObject(Widget As %DeepSee.Dashboard.Widget, CubeName As
 	if $piece(Widget.dataSource, ".", *) = "kpi" {
 		set kpiClass = ##class(%DeepSee.Utils).%GetKPIClass(Widget.dataSource)
 		set obj.kpitype = $classmethod(kpiClass, "%GetSourceType")
-		if (Widget.dataProperties.GetAt(1)) { // check if KPI have dataProperies
-			set widgetData = Widget.dataProperties.GetAt(1) 
-			set obj.format = widgetData.format // duplicating format data in case of KPI
-			} 
+		
 	}
 	
 	// Widget is a portlet
@@ -234,8 +231,16 @@ ClassMethod ProcesstextMeter(Widget As %DeepSee.Dashboard.Widget, Obj As %ZEN.pr
 	for i=1:1:Widget.dataProperties.Count()
 	{
 		set dataProperty = $$$NewDynObj
-		do Widget.dataProperties.GetAt(i).%CopyTo(dataProperty)
-		$$$Insert(Obj.dataProperties,dataProperty)
+		if (Widget.dataProperties.GetAt(i)) // check if widget have dataProperties
+		{ 
+			set widgetData = Widget.dataProperties.GetAt(i)
+			set dataProperty = ..WidgetDataPropertyToProxyObject(widgetData)
+			if $IsObject(dataProperty) 
+			{ 
+				$$$Insert(Obj.dataProperties,dataProperty)
+			}
+
+		}
 	}
 }
 


### PR DESCRIPTION
Deleted assign format to kpi style widget the solution do not worked for multiple text meters on one dash. Replaced %CopyTo on GetAt() in ClassMethod ProcesstextMeter(). For some reason %CopyTo ignored "format" propertie.