### PR TITLE
FIX: issue when DataSource request is empty

### DIFF
--- a/MDX2JSON/Utils.cls
+++ b/MDX2JSON/Utils.cls
@@ -291,7 +291,7 @@ ClassMethod GetDataSource(pDataSource As %String)
 	set st = $$$OK
 	try {
 		
-		if ($FIND(pDataSource, ".pivot") = ($LENGTH(pDataSource) + 1)) {
+		if ($FIND(pDataSource, ".pivot") = ($LENGTH(pDataSource) + 1) && pDataSource '="") {
 			set st = ..OpenPivotByName(pDataSource, .dataSource)
 			return:($$$ISERR(st)) st
 			


### PR DESCRIPTION
If client requested empty string in DataSource endpoint ClassMethod GetDataSource() return status 200. The PR is relative to https://github.com/intersystems-community/DeepSeeWeb/issues/121