### PR TITLE
FIX: remove breaking return statement

### DIFF
--- a/MDX2JSON/Utils.cls
+++ b/MDX2JSON/Utils.cls
@@ -570,7 +570,6 @@ ClassMethod AddWidget(sWidget As %String, sDashboard As %String, key As %String)
 			if (tDash.widgets.GetAt(i).name = sWidget.name)
 			{	
 				set count = 1
-				return $$$ERROR()
 			}
 		}
 


### PR DESCRIPTION
No need to exit from method when names of widgets are similar