### PR TITLE
FIX: replace wrong parameter name

### DIFF
--- a/MDX2JSON/Dashboard.cls
+++ b/MDX2JSON/Dashboard.cls
@@ -142,7 +142,7 @@ ClassMethod WidgetToProxyObject(Widget As %DeepSee.Dashboard.Widget, CubeName As
 		// Linked widgets processing
 		set mdx = ""
 		set basemdx = ""
-		set obj.Link = Widget.dataLink
+		set obj.dataLink = Widget.dataLink
 	}
 	
 	// datasource is a kpi


### PR DESCRIPTION
Parameter dataLink is not received because of this line