### PR TITLE
FIX: errors when dataSource did not exist and cubeName is wrong for some reason

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 sc-list.txt
+.vscode/settings.json

--- a/MDX2JSON/Dashboard.cls
+++ b/MDX2JSON/Dashboard.cls
@@ -290,9 +290,9 @@ ClassMethod WidgetControlToProxyObject(Widget As %DeepSee.Dashboard.Widget, Numb
 	set obj.label = ##class(%DeepSee.UserPortal.Utils).%ResolveText(obj.label)
 	set obj.source = Widget.name
 
-	set filterDataType = ..GetCubeMeasuresDataType(Widget,Number,CubeName,.fDataType)
-	
-	if ('fDataType) 
+	set st = ..GetCubeMeasuresDataType(Widget,Number,CubeName,.fDataType)
+
+	if (st = $$$OK)
 	{
 		set obj.targetPropertyDataType = fDataType
 	}

--- a/MDX2JSON/Dashboard.cls
+++ b/MDX2JSON/Dashboard.cls
@@ -291,7 +291,11 @@ ClassMethod WidgetControlToProxyObject(Widget As %DeepSee.Dashboard.Widget, Numb
 	set obj.source = Widget.name
 
 	set filterDataType = ..GetCubeMeasuresDataType(Widget,Number,CubeName,.fDataType)
-	set obj.targetPropertyDataType = fDataType
+	
+	if ('fDataType) 
+	{
+		set obj.targetPropertyDataType = fDataType
+	}
 	
 	set:(obj.target="") obj.target = Widget.name
 

--- a/MDX2JSON/Utils.cls
+++ b/MDX2JSON/Utils.cls
@@ -573,7 +573,7 @@ ClassMethod AddWidget(sWidget As %String, sDashboard As %String, key As %String)
 		set tWidgets = ##class(%DeepSee.Dashboard.Widget).%New()
 		set st = ..UpdateWidget(tWidgets, sWidget)
 
-		if (st = $$$OK)
+		if (st = $$$OK) // checking for errors in UpdateWidget
 		{
 			$$$Insert(tDash.widgets, tWidgets)
 			do tDash.%Save()
@@ -599,7 +599,7 @@ ClassMethod AddWidget(sWidget As %String, sDashboard As %String, key As %String)
 		}
 		if (changed '= "") {
 			set st = ..UpdateWidget(changed, sWidget)
-			if (st = $$$OK)
+			if (st = $$$OK) // checking for errors in UpdateWidget
 			{
 				do tDash.%Save()	
 			}	

--- a/MDX2JSON/Utils.cls
+++ b/MDX2JSON/Utils.cls
@@ -573,8 +573,11 @@ ClassMethod AddWidget(sWidget As %String, sDashboard As %String, key As %String)
 		set tWidgets = ##class(%DeepSee.Dashboard.Widget).%New()
 		set st = ..UpdateWidget(tWidgets, sWidget)
 
-		$$$Insert(tDash.widgets, tWidgets)
-		do tDash.%Save()
+		if (st = $$$OK)
+		{
+			$$$Insert(tDash.widgets, tWidgets)
+			do tDash.%Save()
+		}
 
 	} else {		
 		// Edit exists widget				
@@ -596,7 +599,10 @@ ClassMethod AddWidget(sWidget As %String, sDashboard As %String, key As %String)
 		}
 		if (changed '= "") {
 			set st = ..UpdateWidget(changed, sWidget)
-			do tDash.%Save()	
+			if (st = $$$OK)
+			{
+				do tDash.%Save()	
+			}	
 		}
 	}		
 		


### PR DESCRIPTION
New logic has been added to the Designer Mode project to control when the user erases or forgets to enter a data source. And logic to check if GetCubeMeasuresDataType sends valid data. The last logic relates to Evgeny Shvarov's request for TRAK

All new logic was first uploaded to the test.pm registry and tested on the production site.